### PR TITLE
Add Nova Wallet

### DIFF
--- a/packages/wallet-connect/src/dotsama/predefinedWallet/NovaWalletLogo.svg
+++ b/packages/wallet-connect/src/dotsama/predefinedWallet/NovaWalletLogo.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg2"
+   width="432"
+   height="432"
+   viewBox="0 0 432 432"
+   sodipodi:docname="Star_black.ai"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,324 H 324 V 0 H 0 Z"
+         id="path14" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <g
+     id="g8"
+     inkscape:groupmode="layer"
+     inkscape:label="Star_black"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,432)">
+    <g
+       id="g10">
+      <g
+         id="g12"
+         clip-path="url(#clipPath16)">
+        <g
+           id="g18"
+           transform="translate(275,159.017)">
+          <path
+             d="m 0,0 v 2.983 2.983 c -18.442,2.938 -58.037,9.763 -77.518,17.221 -6.916,2.622 -12.475,8.136 -15.187,15.052 -7.458,19.391 -14.374,59.212 -17.312,77.744 h -5.966 c -2.938,-18.532 -9.854,-58.353 -17.312,-77.744 -2.712,-6.916 -8.226,-12.385 -15.187,-15.052 C -167.963,15.729 -207.558,8.904 -226,5.966 V 0 c 18.442,-2.938 58.037,-9.763 77.518,-17.221 6.916,-2.622 12.475,-8.136 15.187,-15.052 7.458,-19.391 14.374,-59.212 17.312,-77.744 h 5.966 c 2.938,18.532 9.854,58.353 17.312,77.744 2.712,6.916 8.226,12.385 15.187,15.052 C -58.037,-9.763 -18.442,-2.938 0,0 m -185,164.983 c -49.706,0 -90,-40.294 -90,-90 v -144 c 0,-49.706 40.294,-90 90,-90 h 144 c 49.706,0 90,40.294 90,90 v 144 c 0,49.706 -40.294,90 -90,90 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             id="path20" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/wallet-connect/src/dotsama/predefinedWallet/NovaWalletLogo.svg
+++ b/packages/wallet-connect/src/dotsama/predefinedWallet/NovaWalletLogo.svg
@@ -1,55 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   version="1.1"
-   id="svg2"
-   width="432"
-   height="432"
-   viewBox="0 0 432 432"
-   sodipodi:docname="Star_black.ai"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs6">
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16">
-      <path
-         d="M 0,324 H 324 V 0 H 0 Z"
-         id="path14" />
-    </clipPath>
-  </defs>
-  <sodipodi:namedview
-     id="namedview4"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1" />
-  <g
-     id="g8"
-     inkscape:groupmode="layer"
-     inkscape:label="Star_black"
-     transform="matrix(1.3333333,0,0,-1.3333333,0,432)">
-    <g
-       id="g10">
-      <g
-         id="g12"
-         clip-path="url(#clipPath16)">
-        <g
-           id="g18"
-           transform="translate(275,159.017)">
-          <path
-             d="m 0,0 v 2.983 2.983 c -18.442,2.938 -58.037,9.763 -77.518,17.221 -6.916,2.622 -12.475,8.136 -15.187,15.052 -7.458,19.391 -14.374,59.212 -17.312,77.744 h -5.966 c -2.938,-18.532 -9.854,-58.353 -17.312,-77.744 -2.712,-6.916 -8.226,-12.385 -15.187,-15.052 C -167.963,15.729 -207.558,8.904 -226,5.966 V 0 c 18.442,-2.938 58.037,-9.763 77.518,-17.221 6.916,-2.622 12.475,-8.136 15.187,-15.052 7.458,-19.391 14.374,-59.212 17.312,-77.744 h 5.966 c 2.938,18.532 9.854,58.353 17.312,77.744 2.712,6.916 8.226,12.385 15.187,15.052 C -58.037,-9.763 -18.442,-2.938 0,0 m -185,164.983 c -49.706,0 -90,-40.294 -90,-90 v -144 c 0,-49.706 40.294,-90 90,-90 h 144 c 49.706,0 90,40.294 90,90 v 144 c 0,49.706 -40.294,90 -90,90 z"
-             style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
-             id="path20" />
-        </g>
-      </g>
-    </g>
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.4.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 324 324" style="enable-background:new 0 0 324 324;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#FFFFFF;}
+</style>
+<radialGradient id="SVGID_1_" cx="8.15" cy="19.93" r="372.6356" gradientTransform="matrix(1 0 0 -1 0 326)" gradientUnits="userSpaceOnUse">
+	<stop  offset="5.331913e-02" style="stop-color:#D7D3E9"/>
+	<stop  offset="0.1933" style="stop-color:#A19CDE"/>
+	<stop  offset="0.3834" style="stop-color:#696BD9"/>
+	<stop  offset="0.54" style="stop-color:#3A5AE7"/>
+	<stop  offset="0.7735" style="stop-color:#225FE7"/>
+	<stop  offset="1" style="stop-color:#0883D1"/>
+</radialGradient>
+<path class="st0" d="M84.1,0h155.8C286.3,0,324,37.7,324,84.1v155.8c0,46.5-37.7,84.1-84.1,84.1H84.1C37.7,324,0,286.3,0,239.9V84.1
+	C0,37.7,37.7,0,84.1,0z"/>
+<path class="st1" d="M275,166.7v3c-18.4,2.9-58,9.8-77.5,17.2c-7,2.7-12.5,8.1-15.2,15.1c-7.4,19.4-14.4,59.2-17.3,77.7h-6
+	c-2.9-18.5-9.9-58.4-17.3-77.7c-2.7-6.9-8.2-12.4-15.2-15.1c-19.5-7.5-59-14.3-77.5-17.2v-6c18.4-2.9,58-9.8,77.5-17.2
+	c7-2.7,12.5-8.1,15.2-15.1c7.5-19.4,14.4-59.2,17.3-77.7h6c2.9,18.5,9.9,58.3,17.3,77.7c2.7,6.9,8.2,12.4,15.2,15.1
+	c19.5,7.4,59.1,14.3,77.5,17.2L275,166.7z"/>
 </svg>

--- a/packages/wallet-connect/src/dotsama/predefinedWallet/index.ts
+++ b/packages/wallet-connect/src/dotsama/predefinedWallet/index.ts
@@ -11,6 +11,8 @@ import PolkadotJsLogo from './PolkadotLogo.svg';
 import SubWalletLogo from './SubWalletLogo.svg';
 // @ts-ignore
 import TalismanLogo from './TalismanLogo.svg';
+// @ts-ignore
+import NovaWalletLogo from './NovaWalletLogo.svg';
 
 export const PREDEFINED_WALLETS: WalletInfo[] = [
   {
@@ -47,6 +49,15 @@ export const PREDEFINED_WALLETS: WalletInfo[] = [
     logo: {
       src: FearlessWalletLogo as string,
       alt: 'Fearless Wallet Extension'
+    }
+  },
+  {
+    extensionName: 'polkadot-js',
+    title: 'Nova Wallet',
+    installUrl: 'https://novawallet.io',
+    logo: {
+      src: NovaWalletLogo as string,
+      alt: 'Nova Wallet'
     }
   }
 ];

--- a/packages/wallet-connect/src/evm/predefinedWallet/NovaWalletLogo.svg
+++ b/packages/wallet-connect/src/evm/predefinedWallet/NovaWalletLogo.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg2"
+   width="432"
+   height="432"
+   viewBox="0 0 432 432"
+   sodipodi:docname="Star_black.ai"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,324 H 324 V 0 H 0 Z"
+         id="path14" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <g
+     id="g8"
+     inkscape:groupmode="layer"
+     inkscape:label="Star_black"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,432)">
+    <g
+       id="g10">
+      <g
+         id="g12"
+         clip-path="url(#clipPath16)">
+        <g
+           id="g18"
+           transform="translate(275,159.017)">
+          <path
+             d="m 0,0 v 2.983 2.983 c -18.442,2.938 -58.037,9.763 -77.518,17.221 -6.916,2.622 -12.475,8.136 -15.187,15.052 -7.458,19.391 -14.374,59.212 -17.312,77.744 h -5.966 c -2.938,-18.532 -9.854,-58.353 -17.312,-77.744 -2.712,-6.916 -8.226,-12.385 -15.187,-15.052 C -167.963,15.729 -207.558,8.904 -226,5.966 V 0 c 18.442,-2.938 58.037,-9.763 77.518,-17.221 6.916,-2.622 12.475,-8.136 15.187,-15.052 7.458,-19.391 14.374,-59.212 17.312,-77.744 h 5.966 c 2.938,18.532 9.854,58.353 17.312,77.744 2.712,6.916 8.226,12.385 15.187,15.052 C -58.037,-9.763 -18.442,-2.938 0,0 m -185,164.983 c -49.706,0 -90,-40.294 -90,-90 v -144 c 0,-49.706 40.294,-90 90,-90 h 144 c 49.706,0 90,40.294 90,90 v 144 c 0,49.706 -40.294,90 -90,90 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             id="path20" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/wallet-connect/src/evm/predefinedWallet/NovaWalletLogo.svg
+++ b/packages/wallet-connect/src/evm/predefinedWallet/NovaWalletLogo.svg
@@ -1,55 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   version="1.1"
-   id="svg2"
-   width="432"
-   height="432"
-   viewBox="0 0 432 432"
-   sodipodi:docname="Star_black.ai"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs6">
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16">
-      <path
-         d="M 0,324 H 324 V 0 H 0 Z"
-         id="path14" />
-    </clipPath>
-  </defs>
-  <sodipodi:namedview
-     id="namedview4"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1" />
-  <g
-     id="g8"
-     inkscape:groupmode="layer"
-     inkscape:label="Star_black"
-     transform="matrix(1.3333333,0,0,-1.3333333,0,432)">
-    <g
-       id="g10">
-      <g
-         id="g12"
-         clip-path="url(#clipPath16)">
-        <g
-           id="g18"
-           transform="translate(275,159.017)">
-          <path
-             d="m 0,0 v 2.983 2.983 c -18.442,2.938 -58.037,9.763 -77.518,17.221 -6.916,2.622 -12.475,8.136 -15.187,15.052 -7.458,19.391 -14.374,59.212 -17.312,77.744 h -5.966 c -2.938,-18.532 -9.854,-58.353 -17.312,-77.744 -2.712,-6.916 -8.226,-12.385 -15.187,-15.052 C -167.963,15.729 -207.558,8.904 -226,5.966 V 0 c 18.442,-2.938 58.037,-9.763 77.518,-17.221 6.916,-2.622 12.475,-8.136 15.187,-15.052 7.458,-19.391 14.374,-59.212 17.312,-77.744 h 5.966 c 2.938,18.532 9.854,58.353 17.312,77.744 2.712,6.916 8.226,12.385 15.187,15.052 C -58.037,-9.763 -18.442,-2.938 0,0 m -185,164.983 c -49.706,0 -90,-40.294 -90,-90 v -144 c 0,-49.706 40.294,-90 90,-90 h 144 c 49.706,0 90,40.294 90,90 v 144 c 0,49.706 -40.294,90 -90,90 z"
-             style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
-             id="path20" />
-        </g>
-      </g>
-    </g>
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.4.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 324 324" style="enable-background:new 0 0 324 324;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#FFFFFF;}
+</style>
+<radialGradient id="SVGID_1_" cx="8.15" cy="19.93" r="372.6356" gradientTransform="matrix(1 0 0 -1 0 326)" gradientUnits="userSpaceOnUse">
+	<stop  offset="5.331913e-02" style="stop-color:#D7D3E9"/>
+	<stop  offset="0.1933" style="stop-color:#A19CDE"/>
+	<stop  offset="0.3834" style="stop-color:#696BD9"/>
+	<stop  offset="0.54" style="stop-color:#3A5AE7"/>
+	<stop  offset="0.7735" style="stop-color:#225FE7"/>
+	<stop  offset="1" style="stop-color:#0883D1"/>
+</radialGradient>
+<path class="st0" d="M84.1,0h155.8C286.3,0,324,37.7,324,84.1v155.8c0,46.5-37.7,84.1-84.1,84.1H84.1C37.7,324,0,286.3,0,239.9V84.1
+	C0,37.7,37.7,0,84.1,0z"/>
+<path class="st1" d="M275,166.7v3c-18.4,2.9-58,9.8-77.5,17.2c-7,2.7-12.5,8.1-15.2,15.1c-7.4,19.4-14.4,59.2-17.3,77.7h-6
+	c-2.9-18.5-9.9-58.4-17.3-77.7c-2.7-6.9-8.2-12.4-15.2-15.1c-19.5-7.5-59-14.3-77.5-17.2v-6c18.4-2.9,58-9.8,77.5-17.2
+	c7-2.7,12.5-8.1,15.2-15.1c7.5-19.4,14.4-59.2,17.3-77.7h6c2.9,18.5,9.9,58.3,17.3,77.7c2.7,6.9,8.2,12.4,15.2,15.1
+	c19.5,7.4,59.1,14.3,77.5,17.2L275,166.7z"/>
 </svg>

--- a/packages/wallet-connect/src/evm/predefinedWallet/index.ts
+++ b/packages/wallet-connect/src/evm/predefinedWallet/index.ts
@@ -34,7 +34,7 @@ export const PREDEFINED_EVM_WALLETS: EvmWalletInfo[] = [
     initEvent: 'ethereum#initialized'
   },
   {
-    extensionName: 'NovaWallet',
+    extensionName: 'ethereum',
     title: 'Nova Wallet (EVM)',
     installUrl: 'https://novawallet.io',
     logo: {

--- a/packages/wallet-connect/src/evm/predefinedWallet/index.ts
+++ b/packages/wallet-connect/src/evm/predefinedWallet/index.ts
@@ -7,6 +7,8 @@ import { EvmWalletInfo } from '@subwallet/wallet-connect/types';
 import MetaMaskLogo from './MetaMaskLogo.svg';
 // @ts-ignore
 import SubWalletLogo from './SubWalletLogo.svg';
+// @ts-ignore
+import NovaWalletLogo from './NovaWalletLogo.svg';
 
 export const PREDEFINED_EVM_WALLETS: EvmWalletInfo[] = [
   {
@@ -29,6 +31,17 @@ export const PREDEFINED_EVM_WALLETS: EvmWalletInfo[] = [
       alt: 'MetaMask Extension'
     },
     isSetGlobalString: 'isMetaMask',
+    initEvent: 'ethereum#initialized'
+  },
+  {
+    extensionName: 'NovaWallet',
+    title: 'Nova Wallet (EVM)',
+    installUrl: 'https://novawallet.io',
+    logo: {
+      src: NovaWalletLogo as string,
+      alt: 'NovaWallet (EVM)'
+    },
+    isSetGlobalString: 'isNovaWallet',
     initEvent: 'ethereum#initialized'
   }
 ];


### PR DESCRIPTION
# What have been done
* [x] Added Nova Wallet to `PREDEFINED_WALLETS`
* [x] Tested with test dapp

Note: Didn't find a way how to check whether a dapp is opened on mobile or not. So, Nova Wallet option will fallback to polkadot js or metamask opened not from the Nova Wallet mobile app. Other way around, if the dapp is opened in the Nova Wallet Browser then a user can connect either via Nova Wallet option or Polkadot js/Metamask.

<img width="1198" alt="walletDetection" src="https://github.com/Koniverse/SubConnect/assets/570634/6f48dffc-b85d-42da-bf56-2e6eb7720093">
